### PR TITLE
♻️ rework barcode to be a string

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -452,7 +452,7 @@ paths:
           required: true
           name: barcode
           schema:
-            type: integer
+            type: string
       responses:
         204:
           description: success
@@ -503,7 +503,7 @@ paths:
       parameters:
         - in: path
           required: true
-          type: integer
+          type: string
           name: barcode
           description: barcode associated with user
       responses:
@@ -628,7 +628,7 @@ paths:
           schema:
             type: object
             properties:
-              barcode:
+              id:
                 type: string
               type:
                 type: string
@@ -658,7 +658,7 @@ paths:
         - in: path
           name: id
           required: true
-          type: integer
+          type: string
       responses:
         200:
           description: details of barcode
@@ -678,7 +678,7 @@ paths:
         - in: path
           name: id
           required: true
-          type: integer
+          type: string
       responses:
         204:
           description: barcode deleted
@@ -694,7 +694,7 @@ paths:
         - in: path
           name: id
           required: true
-          type: integer
+          type: string
         - in: body
           name: barcode
           required: false
@@ -1012,15 +1012,12 @@ definitions:
     type: object
     required:
       - id
-      - barcode
       - type
       - linked
       - created_at
       - updated_at
     properties:
       id:
-        type: integer
-      barcode:
         type: string
       type:
         type: string


### PR DESCRIPTION
same as in v1 now.

This is the "lazy" fix for #7 ..

It makes the barcode string again at all places so it should be clear that the barcode string in product is what you use on the /barcodes endpoint.